### PR TITLE
Bump toolkit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@cosmicds/green-comet",
   "version": "0.0.0",
   "dependencies": {
-    "@cosmicds/vue-toolkit": "^0.1.3",
+    "@cosmicds/vue-toolkit": "^0.1.4",
     "@kyvg/vue3-notification": "^2.8.0",
     "@vuepic/vue-datepicker": "^3.6.5",
     "@wwtelescope/astro": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -215,10 +215,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@cosmicds/vue-toolkit@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.1.3.tgz#c29b8c42bb82cd274a7468fba433c6312ef167a6"
-  integrity sha512-D+z2l7x1JqD2RLFgf/pkA3DitIN4/7duGXfsBuAEFM9Kq52cw3Irso57Cw5ud3x3zkWGb0PHN3/jYk0GIVapYw==
+"@cosmicds/vue-toolkit@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@cosmicds/vue-toolkit/-/vue-toolkit-0.1.4.tgz#13ab7585db8c4ac3e17b26b8c2e0900c816d1f99"
+  integrity sha512-3D6zX1+QJsmf/vHM/LivKjzOtmrxkhXa5QSZHqMc0iKZwmHLMcLIIBP7Un6zotBYw1zbHuev0f7PuR4hW9703w==
   dependencies:
     "@fortawesome/fontawesome-svg-core" "^6.5.1"
     "@fortawesome/free-solid-svg-icons" "^6.5.1"


### PR DESCRIPTION
This PR bumps the version of the toolkit used to `0.1.4` so that we can use the NASA Grantee logo.